### PR TITLE
fix: P4PU-694 added label on opex dashboard to distinguish APIM and internal requests

### DIFF
--- a/src/06_domains/cittadini-app/workbooks/OPEXWorkbook.json.tpl
+++ b/src/06_domains/cittadini-app/workbooks/OPEXWorkbook.json.tpl
@@ -120,7 +120,7 @@
                           "additionalResourceOptions": [],
                           "showDefault": false
                         },
-                        "jsonData": "[\r\n    {\"label\":\"APIM\",\"value\":\"apim\",\"selected\": true},\r\n    {\"label\":\"Internal\",\"value\":\"internal\",\"selected\": true}\r\n]",
+                        "jsonData": "[\r\n    {\"label\":\"APIM\",\"value\":\"https://api.${env}.cittadini.pagopa.it\",\"selected\": true},\r\n    {\"label\":\"Internal\",\"value\":\"https://citizen.internal.${env}.cittadini.pagopa.it\",\"selected\": true}\r\n]",
                         "timeContext": {
                           "durationMs": 86400000
                         }
@@ -136,7 +136,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let startTime = {timeRangeOverall:start};\nlet endTime = {timeRangeOverall:end};\nlet interval = totimespan({timeSpan:label});\nlet origin = \"{origin}\";\nlet data = requests\n    | where timestamp between (startTime .. endTime)\n    | where iff( origin == \"apim\", operation_Name startswith \"arc\", url contains \"citizen.internal\");\nlet operationData = data;\nlet totalOperationCount = operationData\n    | summarize Total = count() by operation_Name;\noperationData\n| join kind=inner totalOperationCount on operation_Name\n| summarize\n    Count = count(),\n    Users = dcount(tostring(customDimensions[\"Request-X-Forwarded-For\"])),\n    AvgResponseTime = round(avg(duration), 2)\n    by operation_Name, resultCode, Total\n| project\n    ['Request Name'] = operation_Name,\n    ['Result Code'] = resultCode,\n    ['Total Response'] = Count,\n    ['Rate %'] = (Count * 100) / Total,\n    ['Users Affected'] = Users,\n    ['Avg Response Time (ms)'] = AvgResponseTime\n| sort by ['Total Response'] desc\n\n",
+                    "query": "let startTime = {timeRangeOverall:start};\nlet endTime = {timeRangeOverall:end};\nlet interval = totimespan({timeSpan:label});\nlet originUrl = \"{origin}\";\nlet data = requests\n    | where timestamp between (startTime .. endTime)\n    | where url startswith originUrl and not(name has_any (\"OPTIONS\", \"HEAD\"));\nlet operationData = data;\nlet totalOperationCount = operationData\n    | summarize Total = count() by operation_Name;\noperationData\n| join kind=inner totalOperationCount on operation_Name\n| summarize\n    Count = count(),\n    Users = dcount(tostring(customDimensions[\"Request-X-Forwarded-For\"])),\n    AvgResponseTime = round(avg(duration), 2)\n    by operation_Name, resultCode, Total\n| project\n    ['Request Name'] = operation_Name,\n    ['Result Code'] = resultCode,\n    ['Total Response'] = Count,\n    ['Rate %'] = (Count * 100) / Total,\n    ['Users Affected'] = Users,\n    ['Avg Response Time (ms)'] = AvgResponseTime\n| sort by ['Total Response'] desc\n\n",
                     "size": 0,
                     "showAnalytics": true,
                     "timeContextFromParameter": "timeRangeOverall",
@@ -389,7 +389,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let startTime = {timeRangeOverall:start};\nlet endTime = {timeRangeOverall:end};\nlet interval = totimespan({timeSpan:label});\nlet origin = \"{origin}\";\n\nlet dataset = requests\n    // additional filters can be applied here\n    | where timestamp between (startTime .. endTime)\n    | where iff( origin == \"apim\", operation_Name startswith \"arc\", url contains \"citizen.internal\");\n\ndataset\n| summarize percentile_95=percentile(duration, 95) by bin(timestamp, interval)\n| project timestamp, percentile_95, watermark=1000\n| render timechart",
+                    "query": "let startTime = {timeRangeOverall:start};\nlet endTime = {timeRangeOverall:end};\nlet interval = totimespan({timeSpan:label});\nlet originUrl = \"{origin}\";\n\nlet dataset = requests\n    // additional filters can be applied here\n    | where timestamp between (startTime .. endTime)\n    | where url startswith originUrl and not(name has_any (\"OPTIONS\", \"HEAD\"));\n\ndataset\n| summarize percentile_95=percentile(duration, 95) by bin(timestamp, interval)\n| project timestamp, percentile_95, watermark=1000\n| render timechart",
                     "size": 0,
                     "aggregation": 3,
                     "showAnalytics": true,
@@ -408,7 +408,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let startTime = {timeRangeOverall:start};\nlet endTime = {timeRangeOverall:end};\nlet interval = totimespan({timeSpan:label});\n\nlet tot = requests\n    | where timestamp between (startTime .. endTime) \n    | where operation_Name has 'cittadini'\n    | summarize tot = todouble(count()) by bin(timestamp, interval);\nlet errors = requests\n    | where operation_Name has 'cittadini'\n    | where strcmp(resultCode, \"412\") > 0 \n    | summarize not_ok = count() by bin(timestamp, interval);\ntot\n| join kind=leftouter errors on timestamp\n| project timestamp, availability = (tot - coalesce(not_ok, 0)) / tot, watermark=0.99",
+                    "query": "let startTime = {timeRangeOverall:start};\nlet endTime = {timeRangeOverall:end};\nlet interval = totimespan({timeSpan:label});\nlet originUrl = \"{origin}\";\nlet tot = requests\n    | where timestamp between (startTime .. endTime) \n    | where url startswith originUrl and not(name has_any (\"OPTIONS\", \"HEAD\"))\n    | summarize tot = todouble(count()) by bin(timestamp, interval);\nlet errors = requests\n    | where url startswith originUrl and not(name has_any (\"OPTIONS\", \"HEAD\"))\n    | where strcmp(resultCode, \"412\") > 0 \n    | summarize not_ok = count() by bin(timestamp, interval);\ntot\n| join kind=leftouter errors on timestamp\n| project timestamp, availability = (tot - coalesce(not_ok, 0)) / tot, watermark=0.99",
                     "size": 0,
                     "aggregation": 3,
                     "showAnalytics": true,
@@ -433,7 +433,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let startTime = {timeRangeOverall:start};\r\nlet endTime = {timeRangeOverall:end};\r\nlet interval = totimespan({timeSpan:label});\r\nlet origin = \"{origin}\";\r\nlet data = requests\r\n| where timestamp between (startTime .. endTime)\r\n| where iff( origin == \"apim\", operation_Name startswith \"arc\", url contains \"citizen.internal\");\r\nlet unknowApi = data\r\n| join kind=inner exceptions on operation_Id\r\n| where type has \"OperationNotFound\";\r\nlet totalRequestCount = toscalar (data\r\n| count);\r\nlet joinedUnknowApi = unknowApi\r\n| summarize\r\n        Count = count(),\r\n        Users = dcount(tostring(customDimensions[\"Request-X-Forwarded-For\"]))\r\n        by operation_Name, resultCode, type\r\n| project \r\n        ['Request Name'] = operation_Name,\r\n        ['Result Code'] = resultCode,\r\n        ['Total Response'] = Count,\r\n        ['Rate (% of total requests)'] = (Count * 100) / totalRequestCount,\r\n        ['Users Affected'] = Users,\r\n        ['Type'] = type;\r\nunion joinedUnknowApi",
+                    "query": "let startTime = {timeRangeOverall:start};\r\nlet endTime = {timeRangeOverall:end};\r\nlet interval = totimespan({timeSpan:label});\r\nlet originUrl = \"{origin}\";\r\nlet data = requests\r\n| where timestamp between (startTime .. endTime)\r\n| where url startswith originUrl and not(name has_any (\"OPTIONS\", \"HEAD\"));\r\nlet unknowApi = data\r\n| join kind=inner exceptions on operation_Id\r\n| where type has \"OperationNotFound\";\r\nlet totalRequestCount = toscalar (data\r\n| count);\r\nlet joinedUnknowApi = unknowApi\r\n| summarize\r\n        Count = count(),\r\n        Users = dcount(tostring(customDimensions[\"Request-X-Forwarded-For\"]))\r\n        by operation_Name, resultCode, type\r\n| project \r\n        ['Request Name'] = operation_Name,\r\n        ['Result Code'] = resultCode,\r\n        ['Total Response'] = Count,\r\n        ['Rate (% of total requests)'] = (Count * 100) / totalRequestCount,\r\n        ['Users Affected'] = Users,\r\n        ['Type'] = type;\r\nunion joinedUnknowApi",
                     "size": 1,
                     "showAnalytics": true,
                     "title": "Operation Not Found",

--- a/src/06_domains/cittadini-app/workbooks/OPEXWorkbook.json.tpl
+++ b/src/06_domains/cittadini-app/workbooks/OPEXWorkbook.json.tpl
@@ -120,7 +120,7 @@
                           "additionalResourceOptions": [],
                           "showDefault": false
                         },
-                        "jsonData": "[\r\n    {\"label\":\"APIM\",\"value\":\"apim\",\"selected\": true},\r\n    {\"label\":\"internal\",\"value\":\"internal\",\"selected\": true}\r\n]",
+                        "jsonData": "[\r\n    {\"label\":\"APIM\",\"value\":\"apim\",\"selected\": true},\r\n    {\"label\":\"Internal\",\"value\":\"internal\",\"selected\": true}\r\n]",
                         "timeContext": {
                           "durationMs": 86400000
                         }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
-  added label on opex dashboard to distinguish APIM and internal requests
<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
